### PR TITLE
fix: table_name param from SqlalchemyBackendConfig was ignored

### DIFF
--- a/src/fennflow/backends/sqlalchemy/_backend.py
+++ b/src/fennflow/backends/sqlalchemy/_backend.py
@@ -35,7 +35,7 @@ class SqlalchemyBackend(AbstractBackend):
         )
 
         self._orm_model = create_operation_record_model(
-            table_name=config.scope,
+            table_name=config.table_name,
             schema=config.db_schema,
             dialect=self._engine.dialect.name,
         )


### PR DESCRIPTION
### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] **PR title** is fit for the [release changelog](https://github.com/Alex-FIR-IT/FennFlow/releases).