### PR TITLE
fix: wrap response["Body"] in an async with context manager to resolve streaming resource leak in ContentResponse

### DIFF
--- a/src/fennflow/connectors/s3/core.py
+++ b/src/fennflow/connectors/s3/core.py
@@ -137,14 +137,15 @@ class S3Connector(AbstractConnector[S3Extra]):
         if not response:
             return MediaResponse()
 
-        content_response = ContentResponse(
-            content=ContentFactory.from_bytes(
-                media_type=response["ContentType"],
-                data=await response["Body"].read(),
-                **response.get("Metadata", {}),
-            ),
-            raw_response=response,
-        )
+        async with response["Body"] as stream:
+            content_response = ContentResponse(
+                content=ContentFactory.from_bytes(
+                    media_type=response["ContentType"],
+                    data=await stream.read(),
+                    **response.get("Metadata", {}),
+                ),
+                raw_response=response,
+            )
 
         return MediaResponse.from_content_response(content_response)
 


### PR DESCRIPTION
### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] **PR title** is fit for the [release changelog](https://github.com/Alex-FIR-IT/FennFlow/releases).